### PR TITLE
Support messages too long for the notification.

### DIFF
--- a/demo/Helping/Helping/AZNotificationView.m
+++ b/demo/Helping/Helping/AZNotificationView.m
@@ -99,11 +99,13 @@ static const int NOTIFICATION_VIEW_HEIGHT = 64;
     [self setupNotificationType];
     
     // create the labels
-    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 10, screenBounds.size.width, NOTIFICATION_VIEW_HEIGHT)];
+    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 10, screenBounds.size.width-20, NOTIFICATION_VIEW_HEIGHT)];
     titleLabel.text = _title;
     titleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Light" size:17];
     titleLabel.textColor = [UIColor whiteColor];
-    
+    titleLabel.numberOfLines = 1;
+    titleLabel.minimumScaleFactor = 0.75;
+    titleLabel.adjustsFontSizeToFitWidth = YES;
     [self addSubview:titleLabel];
 }
 

--- a/demo/Helping/Helping/ViewController.m
+++ b/demo/Helping/Helping/ViewController.m
@@ -35,7 +35,7 @@
     }
     else if(tag == 2)
     {
-        [AZNotification showNotificationWithTitle:@"Oh BTW! Your hair is on fire!" controller:self notificationType:AZNotificationTypeWarning];
+        [AZNotification showNotificationWithTitle:@"Oh BTW! Your hair is on fire! This is a really really really long message!" controller:self notificationType:AZNotificationTypeWarning];
     }
     else
     {

--- a/src/AZNotificationView.m
+++ b/src/AZNotificationView.m
@@ -99,10 +99,13 @@ static const int NOTIFICATION_VIEW_HEIGHT = 64;
     [self setupNotificationType];
     
     // create the labels
-    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 10, screenBounds.size.width, NOTIFICATION_VIEW_HEIGHT)];
+    UILabel *titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(10, 10, screenBounds.size.width-20, NOTIFICATION_VIEW_HEIGHT)];
     titleLabel.text = _title;
     titleLabel.font = [UIFont fontWithName:@"HelveticaNeue-Light" size:17];
     titleLabel.textColor = [UIColor whiteColor];
+    titleLabel.numberOfLines = 1;
+    titleLabel.minimumScaleFactor = 0.75;
+    titleLabel.adjustsFontSizeToFitWidth = YES;
     
     [self addSubview:titleLabel];
 }


### PR DESCRIPTION
Hi,

I love your project! It looks amazing and clean and easy to use! I noticed that if the messages are too long for the notification, it just runs off the end without any indication that the message continues. I made a small change where the font shrinks by up to 25% to accommodate slightly longer messages, and clearly shows the "..." at the end of a message which is too long. I hope this is helpful for you. Thank you for making this!

Jason
